### PR TITLE
Feature/generate theme without color packages

### DIFF
--- a/Sources/KvColorPallet-iOS/KvColorPallet.swift
+++ b/Sources/KvColorPallet-iOS/KvColorPallet.swift
@@ -134,4 +134,14 @@ public class KvColorPallet {
     public func generateThemeColorPallet(givenColor: Color) -> AppThemePallet {
         return ThemeGenUtil.generateThemeColorSet(givenColor: givenColor)
     }
+    
+    /**
+     * This method finds the closest KvColor available in the KvColorPallet-iOS to the given color
+     *
+     * @param givenColor: The color to find closest KvColor from color packages
+     * @return KvColor
+     */
+    public func findClosestKvColor(givenColor: Color) -> KvColor {
+        return ColorUtil.findClosestColor(givenColor: givenColor)
+    }
 }

--- a/Sources/KvColorPallet-iOS/KvColorPallet.swift
+++ b/Sources/KvColorPallet-iOS/KvColorPallet.swift
@@ -26,9 +26,8 @@ public class KvColorPallet {
      * On this initiation of kv-color-pallet, we generate a theme color pallet using the given color.
      * `basicColor` is mandatory parameter while initiate the library.
      */
-    public static func initialize(basicColor: KvColor) {
-        let closestColor = ColorUtil.findClosestColor(givenColor: basicColor.color)
-        appThemePallet = instance.generateThemeColorPallet(givenColor: closestColor.color)
+    public static func initialize(basicColor: Color) {
+        appThemePallet = instance.generateThemeColorPallet(givenColor: basicColor)
     }
     
     /**

--- a/Sources/KvColorPallet-iOS/util/ThemeGenUtil.swift
+++ b/Sources/KvColorPallet-iOS/util/ThemeGenUtil.swift
@@ -17,11 +17,9 @@ public class ThemeGenUtil {
      * @param givenColor: base color that need to generate a theme pallet. Theme will generate according to the properties of this color
      * @return AppThemePallet
      */
-    internal static func generateThemeColorSet(givenColor: Color) -> AppThemePallet {
-        let closestColor = ColorUtil.findClosestColor(givenColor: givenColor)
-        
-        let lightColorSet = generateLightThemeColorSet(givenColor: givenColor, closestColor: closestColor)
-        let darkColorSet = generateDarkThemeColorSet(givenColor: givenColor, closestColor: closestColor)
+    internal static func generateThemeColorSet(givenColor: Color) -> AppThemePallet {        
+        let lightColorSet = generateLightThemeColorSet(givenColor: givenColor)
+        let darkColorSet = generateDarkThemeColorSet(givenColor: givenColor)
 
         return AppThemePallet(light: lightColorSet, dark: darkColorSet)
     }
@@ -30,18 +28,16 @@ public class ThemeGenUtil {
      * Generate light theme color pallet
      *
      * @param givenColor: base color that need to generate a theme pallet. Theme will generate according to the properties of this color
-     * @closestColor: Closest color found in KvColorPallet-iOS library to the consumer givenColor
-     *
      * @return ThemeColorPallet
      */
-    private static func generateLightThemeColorSet(givenColor: Color, closestColor: KvColor) -> ThemeColorPallet {
+    private static func generateLightThemeColorSet(givenColor: Color) -> ThemeColorPallet {
         return ThemeColorPallet(
             base: givenColor,
-            primary: closestColor.color,
-            secondary: generateLightSecondaryColor(primaryColor: closestColor.color),
-            tertiary: generateLightTeriaryColor(primaryColor: closestColor),
-            quaternary: closestColor.color, // This is for use light theme primary color dark theme contrast color
-            background: generateLightBackgroundColor(primaryColor: closestColor),
+            primary: givenColor,
+            secondary: generateLightSecondaryColor(primaryColor: givenColor),
+            tertiary: generateLightTeriaryColor(primaryColor: givenColor),
+            quaternary: givenColor, // This is for use light theme primary color dark theme contrast color
+            background: generateLightBackgroundColor(primaryColor: givenColor),
             onPrimary: Color.white,
             onSecondary: Color.white,
             shadow: Color.gray
@@ -52,18 +48,16 @@ public class ThemeGenUtil {
      * Generate dark theme color pallet
      *
      * @param givenColor: base color that need to generate a theme pallet. Theme will generate according to the properties of this color
-     * @closestColor: Closest color found in KvColorPallet-iOS library to the consumer givenColor
-     *
      * @return ThemeColorPallet
      */
-    private static func generateDarkThemeColorSet(givenColor: Color, closestColor: KvColor) -> ThemeColorPallet {
+    private static func generateDarkThemeColorSet(givenColor: Color) -> ThemeColorPallet {
         return ThemeColorPallet(
             base: givenColor,
-            primary: generateDarkPrimaryColor(primaryColor: closestColor.color),
-            secondary: generateDarkSecondaryColor(primaryColor: closestColor.color),
-            tertiary: generateDarkTeriaryColor(primaryColor: closestColor),
-            quaternary: generateDarkSecondaryColor(primaryColor: closestColor.color), // This is for use light theme primary color dark theme contrast color
-            background: generateDarkBackgroundColor(primaryColor: closestColor.color),
+            primary: generateDarkPrimaryColor(primaryColor: givenColor),
+            secondary: generateDarkSecondaryColor(primaryColor: givenColor),
+            tertiary: generateDarkTeriaryColor(primaryColor: givenColor),
+            quaternary: generateDarkSecondaryColor(primaryColor: givenColor), // This is for use light theme primary color dark theme contrast color
+            background: generateDarkBackgroundColor(primaryColor: givenColor),
             onPrimary: Color.white,
             onSecondary: Color.black,
             shadow: Color.white
@@ -76,12 +70,12 @@ public class ThemeGenUtil {
         )
     }
     
-    private static func generateLightTeriaryColor(primaryColor: KvColor) -> Color {
-        return primaryColor.changeColorPackage(colorPackage: ColorPackageType.PK_200).color
+    private static func generateLightTeriaryColor(primaryColor: Color) -> Color {
+        return Color(hue: primaryColor.hsl.hue, saturation: 0.5, brightness: 0.8)
     }
     
-    private static func generateLightBackgroundColor(primaryColor: KvColor) -> Color {
-        return primaryColor.changeColorPackage(colorPackage: ColorPackageType.PK_50).color
+    private static func generateLightBackgroundColor(primaryColor: Color) -> Color {
+        return Color(hue: primaryColor.hsl.hue, saturation: 0.05, brightness: 1)
     }
     
     private static func generateDarkPrimaryColor(primaryColor: Color) -> Color {
@@ -96,8 +90,8 @@ public class ThemeGenUtil {
         )
     }
     
-    private static func generateDarkTeriaryColor(primaryColor: KvColor) -> Color {
-        return primaryColor.changeColorPackage(colorPackage: ColorPackageType.PK_700).color
+    private static func generateDarkTeriaryColor(primaryColor: Color) -> Color {
+        return Color(hue: primaryColor.hsl.hue, saturation: 1, brightness: 0.5)
     }
     
     private static func generateDarkBackgroundColor(primaryColor: Color) -> Color {


### PR DESCRIPTION
# Theme generation without color packages
This change is to independent the theme generation functionality from available color packages in KvColorPallet-iOS library. With this, consumer can pass any swift-ui `Color` they preferred instead of `KvColor` from library.

#### commits:
* [Open find closest color functionality](https://github.com/KvColorPallet/KvColorPallet-iOS/commit/466b392974118b38c57b3c4af1adc1edbc2eb00f)
* [Change the library initiation](https://github.com/KvColorPallet/KvColorPallet-iOS/commit/4ca4fb433511c4799f4fb3c5b380e107dac1136d)
* [Make the themeGen independent from KvColor object](https://github.com/KvColorPallet/KvColorPallet-iOS/commit/cf3c2159e084e623b9bc507eaf959175c2fe5f98)

#### bug fixing:
* [Accept any swift-ui color to generate themes instead of KvColor](https://github.com/KvColorPallet/KvColorPallet-iOS/issues/9)
* [Introduce new colors to color pallet](https://github.com/KvColorPallet/KvColorPallet-iOS/issues/4)