### PR TITLE
Feature/improve capabilities

### DIFF
--- a/Sources/KvColorPalette-iOS/extension/Extension.swift
+++ b/Sources/KvColorPalette-iOS/extension/Extension.swift
@@ -26,38 +26,6 @@ internal extension Color {
     }
     
     /**
-     * Seperate rgb (red, green, blue) colors of given color's components
-     */
-    var rgb: (red: CGFloat, green: CGFloat, blue: CGFloat, opacity: CGFloat) {
-        typealias uiColor = UIColor
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var opasity: CGFloat = 0
-        
-        guard uiColor(self).getRed(&red, green: &green, blue: &blue, alpha: &opasity) else {
-            return (0,0,0,0)
-        }
-        
-        return (red, green, blue, opasity)
-    }
-    
-    /**
-     * Separate hsl (hue, saturation and brightness) of the given color.
-     */
-    var hsl: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
-        var hue: CGFloat  = 0.0
-        var saturation: CGFloat = 0.0
-        var brightness: CGFloat = 0.0
-        var alpha: CGFloat = 0.0
-        
-        let uiColor = UIColor(self)
-        uiColor.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
-        
-        return (hue, saturation, brightness, alpha)
-    }
-    
-    /**
      * Return hex value of the color
      */
     var hex: String {

--- a/Sources/KvColorPalette-iOS/extension/Extension.swift
+++ b/Sources/KvColorPalette-iOS/extension/Extension.swift
@@ -26,6 +26,27 @@ internal extension Color {
     }
     
     /**
+     * Accept hex value to generate color
+     * @param hex [String] String value of hex [#ffffff or #000000]
+     * This is a nullable return
+     */
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.hasPrefix("#") ? String(hexSanitized.dropFirst()) : hexSanitized
+
+        guard hexSanitized.count == 6 else { return nil }
+
+        var rgbValue: UInt64 = 0
+        Scanner(string: hexSanitized).scanHexInt64(&rgbValue)
+
+        let red = Double((rgbValue >> 16) & 0xFF) / 255.0
+        let green = Double((rgbValue >> 8) & 0xFF) / 255.0
+        let blue = Double(rgbValue & 0xFF) / 255.0
+
+        self.init(red: red, green: green, blue: blue)
+    }
+    
+    /**
      * Return hex value of the color
      */
     var hex: String {

--- a/Sources/KvColorPalette-iOS/extension/OpenExtension.swift
+++ b/Sources/KvColorPalette-iOS/extension/OpenExtension.swift
@@ -45,6 +45,17 @@ public extension Color {
     }
     
     /**
+     * Extension property to check if a [Color] is a high-light color.
+     */
+    var isHightLightColor: Bool {
+        return if hsl.brightness >= 0.7 {
+            true
+        } else {
+            false
+        }
+    }
+    
+    /**
      * Expose the theme-color pallet in `Color` object in SwiftUI.
      */
     public static var themePalette: ThemeColorPalette {

--- a/Sources/KvColorPalette-iOS/extension/OpenExtension.swift
+++ b/Sources/KvColorPalette-iOS/extension/OpenExtension.swift
@@ -13,6 +13,38 @@ import SwiftUICore
 public extension Color {
     
     /**
+     * Seperate rgb (red, green, blue) colors of given color's components
+     */
+    var rgb: (red: CGFloat, green: CGFloat, blue: CGFloat, opacity: CGFloat) {
+        typealias uiColor = UIColor
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var opasity: CGFloat = 0
+        
+        guard uiColor(self).getRed(&red, green: &green, blue: &blue, alpha: &opasity) else {
+            return (0,0,0,0)
+        }
+        
+        return (red, green, blue, opasity)
+    }
+    
+    /**
+     * Separate hsl (hue, saturation and brightness) of the given color.
+     */
+    var hsl: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
+        var hue: CGFloat  = 0.0
+        var saturation: CGFloat = 0.0
+        var brightness: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
+        
+        let uiColor = UIColor(self)
+        uiColor.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+        
+        return (hue, saturation, brightness, alpha)
+    }
+    
+    /**
      * Expose the theme-color pallet in `Color` object in SwiftUI.
      */
     public static var themePalette: ThemeColorPalette {

--- a/Sources/KvColorPalette-iOS/util/ColorUtil.swift
+++ b/Sources/KvColorPalette-iOS/util/ColorUtil.swift
@@ -10,13 +10,38 @@ import SwiftUICore
 public class ColorUtil {
     
     /**
+     * Validate if given color hex is valid
+     *
+     * @param colorHex hex color String
+     * @return [Boolean]
+     */
+    public static func validateColorHex(colorHex: String) -> Bool {
+        let colorHexRegex = "^#([A-Fa-f0-9]{6})$"
+        return colorHex.range(of: colorHexRegex, options: .regularExpression) != nil
+    }
+    
+    /**
      * Convert hex color to [Color]
      *
-     * @param color hex color String
+     * @param color hex color UInt
      * @return [Color]
      */
-    public static func getColorFromHex(colorHex: UInt) -> Color {
+    public static func getColorFromHexUInt(colorHex: UInt) -> Color {
         return Color(hex: colorHex)
+    }
+    
+    /**
+     * Convert hex color to [Color]
+     *
+     *@param color hex color String
+     *@return [Color] - Nullable
+     */
+    public static func getColorFromHexString(colorHex: String) -> Color? {
+        if validateColorHex(colorHex: colorHex) {
+            return Color(hex: colorHex)
+        } else {
+            return nil
+        }
     }
     
     /**


### PR DESCRIPTION
# Improve with few capabilities
This changers introduce new capabilities to the KvColorPalette-iOS libaray
* Generate color from color-hex as a String
* Get rgb (red, green, blue) properties of the color as a extension to Color object
* Get hsl (hue, saturation, lightness (brightness)) properties of the color as extension to Color object

#### commits:
* [Add an extension property to Color object.](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/c833e00782498419b81591054468b2ff2ad59191)
* [Color from String Hex](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/6b8839d3d7ba2539e2735e14854ed3c97a8929f6)
* [Open up .rgb and .hsl](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/b1e7f98ec7f293b8e7c3ebd399b91a1780655b32)