### PR TITLE
Feature/pass color count for color palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This library simplifies the process of building consistent and visually appealin
 ```
 dependencies: [
     ....
-    .package(url: "https://github.com/KvColorPalette/KvColorPalette-iOS", from: "1.2.0"),
+    .package(url: "https://github.com/KvColorPalette/KvColorPalette-iOS", from: "1.3.0"),
 ]
 ```
 
@@ -49,13 +49,13 @@ If you wants to consume basic features in `KvColorPalette-iOS` then use singleto
 KvColorPalette.instance.generateColorPalette(givenColor: MatPackage().matGold)
 
 // Generate alpha color schem of given color
-KvColorPalette.instance.generateAlphaColorPalette(givenColor: MatPackage().matGold.color)
+KvColorPalette.instance.generateAlphaColorPalette(givenColor: MatPackage().matGold.color, colorCount: 8)
 
 // Generate brigtness (lightness) color schem of given color
-KvColorPalette.instance.generateBrightnessColorPalette(givenColor: MatPackage().matGold.color)
+KvColorPalette.instance.generateBrightnessColorPalette(givenColor: MatPackage().matGold.color, colorCount: 12)
 
 // Generate saturation color schem of given color
-KvColorPalette.instance.generateSaturationColorPalette(givenColor: MatPackage().matGold.color)
+KvColorPalette.instance.generateSaturationColorPalette(givenColor: MatPackage().matGold.color, colorCount: 15)
 
 // Generate theme color pallet of given color
 KvColorPalette.instance.generateThemeColorPalette(givenColor: MatPackage().matGold)

--- a/Sources/KvColorPalette-iOS/KvColorPalette.swift
+++ b/Sources/KvColorPalette-iOS/KvColorPalette.swift
@@ -110,18 +110,15 @@ public class KvColorPalette {
         let hue = givenColor.hsl.hue
         let brightness = givenColor.hsl.brightness
         
-        return [
-            Color(hue: hue, saturation: 1, brightness: brightness),
-            Color(hue: hue, saturation: 0.9, brightness: brightness),
-            Color(hue: hue, saturation: 0.8, brightness: brightness),
-            Color(hue: hue, saturation: 0.7, brightness: brightness),
-            Color(hue: hue, saturation: 0.6, brightness: brightness),
-            Color(hue: hue, saturation: 0.5, brightness: brightness),
-            Color(hue: hue, saturation: 0.4, brightness: brightness),
-            Color(hue: hue, saturation: 0.3, brightness: brightness),
-            Color(hue: hue, saturation: 0.2, brightness: brightness),
-            Color(hue: hue, saturation: 0.1, brightness: brightness),
-        ]
+        var colorList: [Color] = []
+        let reviceColorCount = ColorUtil.validateAndReviseColorCount(colorCount: colorCount)
+        
+        for i in stride(from: reviceColorCount, to: 0, by: -1) {
+            let colorSaturation = 1.0/Double(reviceColorCount)*Double(i)
+            colorList.append(Color(hue: hue, saturation: colorSaturation, brightness: brightness))
+        }
+        
+        return colorList
     }
     
     /**

--- a/Sources/KvColorPalette-iOS/KvColorPalette.swift
+++ b/Sources/KvColorPalette-iOS/KvColorPalette.swift
@@ -63,9 +63,10 @@ public class KvColorPalette {
      */
     public func generateAlphaColorPalette(givenColor: Color, colorCount: Int = 10) -> [Color] {
         var colorList: [Color] = []
+        let reviceColorCount = ColorUtil.validateAndReviseColorCount(colorCount: colorCount)
         
-        for i in stride(from: colorCount, to: 0, by: -1) {
-            let colorAlpha = 1.0/Double(colorCount)*Double(i)
+        for i in stride(from: reviceColorCount, to: 0, by: -1) {
+            let colorAlpha = 1.0/Double(reviceColorCount)*Double(i)
             colorList.append(givenColor.opacity(colorAlpha))
         }
         

--- a/Sources/KvColorPalette-iOS/KvColorPalette.swift
+++ b/Sources/KvColorPalette-iOS/KvColorPalette.swift
@@ -57,9 +57,11 @@ public class KvColorPalette {
      * this method generate a list of colors with different alpha values.
      *
      * @param givenColor The color to generate the alpha values for.
+     * @param colorCount The number of colors to generate. In default that returns 10 colors. This accept integer value in a range of 2 - 30.
+     * Even someone passes number more than 30, this will returns only 30 colors.
      * @return A list of colors with alpha values.
      */
-    public func generateAlphaColorPalette(givenColor: Color) -> [Color] {
+    public func generateAlphaColorPalette(givenColor: Color, colorCount: Int = 10) -> [Color] {
         return [
             givenColor.opacity(1),
             givenColor.opacity(0.9),
@@ -79,9 +81,11 @@ public class KvColorPalette {
      * this method generate a list of colors with different brightnesses.
      *
      * @param givenColor The color to generate the brightness values for.
+     * @param colorCount The number of colors to generate. In default that returns 10 colors. This accept integer value in a range of 2 - 30.
+     * Even someone passes number more than 30, this will returns only 30 colors.
      * @return A list of colors.
      */
-    public func generateBrightnessColorPalette(givenColor: Color) -> [Color] {
+    public func generateBrightnessColorPalette(givenColor: Color, colorCount: Int = 10) -> [Color] {
         let hue = givenColor.hsl.hue
         let saturation = givenColor.hsl.saturation
         
@@ -104,9 +108,11 @@ public class KvColorPalette {
      * this method generate a list of colors with different saturations.
      *
      * @param givenColor The color to generate the saturation values for.
+     * @param colorCount The number of colors to generate. In default that returns 10 colors. This accept integer value in a range of 2 - 30.
+     * Even someone passes number more than 30, this will returns only 30 colors.
      * @return A list of colors.
      */
-    public func generateSaturationColorPalette(givenColor: Color) -> [Color] {
+    public func generateSaturationColorPalette(givenColor: Color, colorCount: Int = 10) -> [Color] {
         let hue = givenColor.hsl.hue
         let brightness = givenColor.hsl.brightness
         

--- a/Sources/KvColorPalette-iOS/KvColorPalette.swift
+++ b/Sources/KvColorPalette-iOS/KvColorPalette.swift
@@ -62,18 +62,14 @@ public class KvColorPalette {
      * @return A list of colors with alpha values.
      */
     public func generateAlphaColorPalette(givenColor: Color, colorCount: Int = 10) -> [Color] {
-        return [
-            givenColor.opacity(1),
-            givenColor.opacity(0.9),
-            givenColor.opacity(0.8),
-            givenColor.opacity(0.7),
-            givenColor.opacity(0.6),
-            givenColor.opacity(0.5),
-            givenColor.opacity(0.4),
-            givenColor.opacity(0.3),
-            givenColor.opacity(0.2),
-            givenColor.opacity(0.1),
-        ]
+        var colorList: [Color] = []
+        
+        for i in stride(from: colorCount, to: 0, by: -1) {
+            let colorAlpha = 1.0/Double(colorCount)*Double(i)
+            colorList.append(givenColor.opacity(colorAlpha))
+        }
+        
+        return colorList
     }
     
     /**

--- a/Sources/KvColorPalette-iOS/KvColorPalette.swift
+++ b/Sources/KvColorPalette-iOS/KvColorPalette.swift
@@ -86,18 +86,15 @@ public class KvColorPalette {
         let hue = givenColor.hsl.hue
         let saturation = givenColor.hsl.saturation
         
-        return [
-            Color(hue: hue, saturation: saturation, brightness: 1),
-            Color(hue: hue, saturation: saturation, brightness: 0.9),
-            Color(hue: hue, saturation: saturation, brightness: 0.8),
-            Color(hue: hue, saturation: saturation, brightness: 0.7),
-            Color(hue: hue, saturation: saturation, brightness: 0.6),
-            Color(hue: hue, saturation: saturation, brightness: 0.5),
-            Color(hue: hue, saturation: saturation, brightness: 0.4),
-            Color(hue: hue, saturation: saturation, brightness: 0.3),
-            Color(hue: hue, saturation: saturation, brightness: 0.2),
-            Color(hue: hue, saturation: saturation, brightness: 0.1),
-        ]
+        var colorList: [Color] = []
+        let reviceColorCount = ColorUtil.validateAndReviseColorCount(colorCount: colorCount)
+        
+        for i in stride(from: reviceColorCount, to: 0, by: -1) {
+            let colorBrightness = 1.0/Double(reviceColorCount)*Double(i)
+            colorList.append(Color(hue: hue, saturation: saturation, brightness: colorBrightness))
+        }
+        
+        return colorList
     }
     
     /**

--- a/Sources/KvColorPalette-iOS/util/ColorUtil.swift
+++ b/Sources/KvColorPalette-iOS/util/ColorUtil.swift
@@ -133,4 +133,15 @@ public class ColorUtil {
             return closestColor
         }
     }
+    
+    /**
+     * Validate the color count requested by the user in the color palette.
+     * If the color count is greater than 30, then it will return 30. If the color count is less than 1, then it will return 1.
+     *
+     * @param colorCount [Int] The number of colors to generate.
+     * @return Int: The validated color count.
+     */
+    internal static func validateAndReviseColorCount(colorCount: Int) -> Int {
+        return if colorCount >= 30 { 30 } else if colorCount <= 1 { 1 } else { colorCount }
+    }
 }


### PR DESCRIPTION
# Color count for color palette
This change introduce a new parameter as `colorCount` to the APIs that generate color palette from color alpha, color saturation, color lightness properties. Consumer can provide integer value in rage of 1 - 30 and according to the number consumer provide it generate a number of colors in color palette.

#### commits:
* [Update the README.md for new API changes](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/bb6c51fe3f46c922bc28415bf20ea8717b9a017f)
* [Generate the saturation color palette according to the color count](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/d713049d36190b7d8fc70b4cdbd18215242f1e16)
* [Generate the brightness color palette according to the color count](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/d5750c17ecc148a326d3122ff283af940084fdef)
* [Introduce a color count validator method](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/981be4a8c3c7a22600821b3c82a795ddffba50e5)
* [Generate the alpha color palette according to the color count](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/c338f94620219cc4fa50e26029ebbe46b229f932)
* [Add the parameter to color palette generation methods](https://github.com/KvColorPalette/KvColorPalette-iOS/commit/bc3d8312baf06a79ae8aad36e05c3b79004dec9c)

